### PR TITLE
Update the README.md and remove window.onmove

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # Explainer for Additional Windowing Controls
 
-This proposal is an early design sketch by Chrome's Web Apps & Capabilities (Fugu) team to describe the problem below and solicit feedback on the proposed solution. It has not been approved to ship in Chrome.
-
 ## Introduction
 
 This proposal introduces additional ways for web applications to introspect and control their windows, to enable critical window management functionality on the web platform.
 
-The proposed enhancement would allow web applications to maximize, minimize, and restore their windows and introspect that window display state. Further, it allows applications to be notified when the window is repositioned, and control whether the window can be resized.
+The proposed enhancement would allow web applications to maximize, minimize, and restore their windows, control whether the window can be resized, and introspect the window state related to the mentioned controls, that is the window display state and ability to be resized by the user.
 
 The [window management permission](https://w3c.github.io/window-management/#api-permissions) will be required for the new JS APIs (window.maximize()/minimize()/restore()/setResizable(bool)).
-The new CSS media features `display-state` and `resizable` are not gated behind a permission as they can follow the non-AWC API toggled states as well. Also window.onmove event won't be gated behind any permission and unlike other APIs, it will be available to normal browser window too (not just web apps).
+The new CSS media features `display-state` and `resizable` are not gated behind a permission as they can follow the non-AWC API toggled states as well.
 
 
 ## Background
@@ -20,7 +18,7 @@ The new CSS media features `display-state` and `resizable` are not gated behind 
 
 [Window Controls Overlay](https://wicg.github.io/window-controls-overlay/) offers new capabilities for web applications to control the area that would generally be occupied by the title bar in an installed web application running on a desktop environment. That specification also allows applications to [define draggable regions or content](https://wicg.github.io/window-controls-overlay/#defining-draggable-sections), which is highly relevant to this proposal.
 
-Demo glitch app that ties in proposals from this doc https://seamless-titlebar-example.glitch.me/
+Demo app that ties in proposals from this doc https://awc-demo-4a08a808.web.app/
 
 
 ## Problem and Use Cases
@@ -31,11 +29,11 @@ VDI web clients have limited abilities to integrate remote application windows w
 <p align="center"><sub>Remote window presented within a local window</sub></p>
 
 
-Several VDI clients, including Citrix and VMWare, have reported that their users strongly desire an integrated experience as their work is increasingly happening both on local client and remote host devices.
+Several VDI clients, including Citrix and Omnissa, have reported that their users strongly desire an integrated experience as their work is increasingly happening both on local client and remote host devices.
 
-Unfortunately, the web platform offers no means for web applications to signal the user agent when users interact with remote application (or custom) window controls. Further, web applications cannot introspect the local window’s display state, and must poll for local window position changes. These platform gaps create disconnects between local and remote windows, and prevent web VDI clients from offering functionality expected by users.
+Unfortunately, the web platform offers no means for web applications to signal the user agent when users interact with remote application (or custom) window controls. This platform gap create disconnects between local and remote windows, and prevent web VDI clients from offering functionality expected by users.
 
-These missing capabilities also prevent a broader set of web applications from offering compelling window management experiences for their users.
+The missing capabilities also prevent a broader set of web applications from offering compelling window management experiences for their users.
 
 
 ## Proposal
@@ -46,7 +44,6 @@ This proposal seeks to enable local web applications to convey a user's intended
 
 *   `await window.minimize()/maximize()/restore()` changes the window display state
 *   `display-state` CSS media feature yields the current window display state
-*   `window.onmove` event is fired when the window moves
 *   `await window.setResizable(bool)` sets whether the window is user-resizable
 *   `resizable` CSS media feature yields whether the window is user-resizable
 
@@ -73,39 +70,11 @@ An [open proposal to standardize](https://github.com/w3c/csswg-drafts/issues/701
 }
 ```
 
-
-
-### Obviate the need for polling window positions
-
-A new `move` event on `window` fires when the window’s position changes, in a pattern similar to the existing window <code>[resize](https://w3c.github.io/csswg-drafts/cssom-view-1/#resizing-viewports)</code> event, if the site has permission. When a user-agent determines that the window’s top left corner at coordinates (x, y) has moved (e.g. as a result of the user repositioning the browser window), run these steps:
-
-
-
-1. If the site doesn’t have the Window Management permission, abort these steps.
-2. Update the `window.screenX` and `window.screenY` properties with the new coordinates.
-3. Fire an event named `move` at the `window` object.
-
-`Move` events will not be fired at background pages - when the page regains focus a single coalesced event will be fired (similar to how the `resize` event works). This is to prevent cross-site tracking amongst tabs in the same window.
-
-See related specification material for [moveTo](https://w3c.github.io/csswg-drafts/cssom-view-1/#dom-window-moveto), [resizeTo](https://w3c.github.io/csswg-drafts/cssom-view-1/#dom-window-resizeto) & [resize](https://w3c.github.io/csswg-drafts/cssom-view-1/#resizing-viewports).
-
-
-```js
-window.addEventListener('move', () =>
-  console.log('New window position: ${window.screenX}, ${window.screenY}'));
-```
-
-
-This obviates the need for polling if a web application wants to save a user’s window placement and restore that on their next session, or change the relative placement of remote windows in response to changes of their local counterparts.
-
-That second use case is particularly important if VDI implementations use a single composited framebuffer to capture remote application window content from a composited view of the remote desktop. In that case, local and remote window placements must be synchronized, so that remote window occlusions (their overlaps) correspond with their local counterparts.
-
-
 ### Support custom and remote window display state controls
 
 In order to provide web applications the ability to integrate a remote application’s window controls with the local window manager, we propose adding new `window.minimize()/maximize()/restore()` async APIs.
 
-In addition the app needs to be able to 1) query the current window display state (`window.displayState` property), and 2) receive window display state change events (new `displaystatechange` event which fires when the window display state changes). This is so that the app can eg. toggle maximize/restore buttons.
+In addition the app needs to be able to 1) query the current window display state (`display-state` CSS property), and 2) receive window display state change events (by listening for `change` event on the `MediaQueryList` created by calling `matchMedia()` on the `window` object). This is so that the app can eg. toggle maximize/restore buttons.
 
 Code example of manually rolling the buttons (ref. [Electron seamless titlebar tutorial](https://github.com/binaryfunt/electron-seamless-titlebar-tutorial)):
 
@@ -208,7 +177,7 @@ try {
 ```
 
 
-New `window.minimize()/maximize()/restore()` async APIs ask the user agent to perform the operation on the provided window object. They return a Promise which is resolved once the operation has succeeded, or is rejected if there was an error (lack of necessary permission for the API).
+New `window.minimize()/maximize()/restore()` async APIs ask the user agent to perform the operation on the provided window object. They return a Promise which is resolved once the operation has succeeded, or is rejected if there was an error (lack of necessary permission for the API, request was rejected or discarded by the operating system).
 
 
 
@@ -216,9 +185,9 @@ New `window.minimize()/maximize()/restore()` async APIs ask the user agent to pe
 *   `minimize()/maximize()/restore()` operations follow platform convention.
 *   [Snapped states](https://support.microsoft.com/en-us/windows/snap-your-windows-885a9b1e-a983-a3b1-16cd-c531795e6241) aren’t typically exposed to nor initiated by client applications on desktop platforms, and each platform does them a little differently. They are out of scope here.
 
-A new `display-state` CSS media feature indicates the current display state of the window. Possible values are `normal/minimized/maximized/fullscreen`. The property will always contain the value `normal` if there was an error (e.g. a lack of permission).
+A new `display-state` CSS media feature indicates the current display state of the window. Possible values are `normal/minimized/maximized/fullscreen`. The property will always contain the value `normal` if there was an error.
 
-A new `window.setResizable(bool)` async API asks the user agent to set whether users can resize the provided window object. It returns a Promise which is successfully resolved, or is rejected if there was an error (lack of permission). This allows VDI client applications to request that local windows match the behavior of the remote window.
+A new `window.setResizable(bool)` async API asks the user agent to set whether users can resize the provided window object. It returns a Promise which is successfully resolved, or is rejected if there was an error (lack of permission, request rejected by the operating system). This allows VDI client applications to request that local windows match the behavior of the remote window.
 
 This API requests that the user agent prevent resize drag handles on top-level windows, and it has no effect on iframe windows. Maximize is prevented, but minimize and restore still work as expected. Not all resizes can be prevented (e.g. window being moved to another display with a size smaller than the window) and it’s ultimately the client app's responsibility to handle such cases.
 While user-initiated attempts to enter fullscreen are prevented, applications can still utilize the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) (i.e. `Element.requestFullscreen()`)  to request fullscreen programmatically. To prevent script-initiated fullscreen requests, developers can override `Element.prototype.requestFullscreen`, set an [HTTP `fullscreen` permission-policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/fullscreen) or use the [FullscreenAllowed](https://chromeenterprise.google/policies/#FullscreenAllowed) enterprise policy for managed sessions.
@@ -265,18 +234,18 @@ A new `resizable` CSS media feature indicates whether the provided window object
         * [change event](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event) for free (don’t need to specify a separate `displaystatechange` event)
     * CONs:
         * Limited avenues for permission gating:
-            * Always yield `normal` for `display-state`, `true` for `resizable` without permission
+            * Always yield `normal` for `display-state`, `true` for `resizable` without permission if the proposal was modified a permission was required to read the values
 * Sync `window.displayState` and `window.resizable` attributes and a `displaystatechange` event on `window`
     * PROs:
         * Straightforward and convenient
         * Alignment with existing attributes on the window object
         * Ergonomic sync attribute access from event handlers
     * CONs:
-        * Limited avenues for permission gating:
-            * Always yield `normal` for `displayState`, `true` for `resizable` without permission
-            * Do not fire `displaystatechange` without permission, or fire it immediately when a handler is added with a "permission missing" error.
         * Increases the fingerprinting surface of the user agent
         * Adds new attributes on a global interface
+        * Limited avenues for permission gating if the proposal was modified a permission was required to read the values:
+            * Always yield `normal` for `displayState`, `true` for `resizable` without permission
+            * Do not fire `displaystatechange` without permission, or fire it immediately when a handler is added with a "permission missing" error.
 * Async `await window.getDisplayState()` yields the current window display state value (& similar `await window.getResizable()` yields whether the window is resizable)
     * PROs:
         * Simple well-defined API shape with one purpose
@@ -335,7 +304,6 @@ JS APIs usage would be gated by:
 *   `window.minimize()/maximize()/restore()` are limited to:
     *   Windows with ‘standalone’ or ‘minimal-ui’ [display-mode](https://www.w3.org/TR/mediaqueries-5/#display-mode), i.e. installed application windows, and origins running in their own window, whether installed or not, e.g. Chrome’s “Create shortcut…” with  “Open as window” checked
     *   Popup windows created by script, i.e. `window.open()` 
-*   `window.onmove` event is allowed for origins in a tab, since they can already access `window.screenX|Y`, but it is only fired on foreground tabs, to prevent cross-site tracking amongst background tabs in the same window.
 
 Here are the most prevalent concerns raised by this API. Malicious sites may wish to:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ VDI web clients have limited abilities to integrate remote application windows w
 
 Several VDI clients, including Citrix and Omnissa, have reported that their users strongly desire an integrated experience as their work is increasingly happening both on local client and remote host devices.
 
-Unfortunately, the web platform offers no means for web applications to signal the user agent when users interact with remote application (or custom) window controls. This platform gap create disconnects between local and remote windows, and prevent web VDI clients from offering functionality expected by users.
+Unfortunately, the web platform offers no means for web applications to signal the user agent when users interact with remote application (or custom) window controls. This platform gap creates a disconnect between local and remote windows, and prevents web VDI clients from offering functionality expected by users.
 
 The missing capabilities also prevent a broader set of web applications from offering compelling window management experiences for their users.
 
@@ -234,7 +234,7 @@ A new `resizable` CSS media feature indicates whether the provided window object
         * [change event](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/change_event) for free (don’t need to specify a separate `displaystatechange` event)
     * CONs:
         * Limited avenues for permission gating:
-            * Always yield `normal` for `display-state`, `true` for `resizable` without permission if the proposal was modified a permission was required to read the values
+            * Always yield `normal` for `display-state`, `true` for `resizable` without permission if the proposal was modified and a permission was required to read the values
 * Sync `window.displayState` and `window.resizable` attributes and a `displaystatechange` event on `window`
     * PROs:
         * Straightforward and convenient
@@ -243,7 +243,7 @@ A new `resizable` CSS media feature indicates whether the provided window object
     * CONs:
         * Increases the fingerprinting surface of the user agent
         * Adds new attributes on a global interface
-        * Limited avenues for permission gating if the proposal was modified a permission was required to read the values:
+        * Limited avenues for permission gating if the proposal was modified and a permission was required to read the values:
             * Always yield `normal` for `displayState`, `true` for `resizable` without permission
             * Do not fire `displaystatechange` without permission, or fire it immediately when a handler is added with a "permission missing" error.
 * Async `await window.getDisplayState()` yields the current window display state value (& similar `await window.getResizable()` yields whether the window is resizable)
@@ -291,6 +291,11 @@ An alternative to the JS API would be to extend `app-region` CSS to support mini
 ### Replacing window.setResizable() with manifest property and window.open() feature (static vs. dynamic resizable)
 
 The window resizable property could be set statically during window creation (via either manifest property or window.open() feature), but this doesn’t cover all of the VDI clients use-cases as the property could change dynamically during window life-time (since they display remote windows).
+
+
+### Introduction of window.onmove event to obviate the need for polling window positions
+
+A `move` event on `window` was initially suggested as a part of this proposal. It was rejected because of privacy concerns (see discussions [here](https://github.com/w3c/csswg-drafts/issues/7693) and [here](https://github.com/WebKit/standards-positions/issues/289)).
 
 ## Security & Privacy Considerations
 


### PR DESCRIPTION
This commit removes the window.onmove event after it was rejected by the CSS Working Group (https://github.com/w3c/csswg-drafts/issues/7693) and introduces some small fixes/updates after reviewing it.